### PR TITLE
Adaptar estilos para andino

### DIFF
--- a/ckanext/seriestiempoarexplorer/fanstatic/assets/css/andino_styles.css
+++ b/ckanext/seriestiempoarexplorer/fanstatic/assets/css/andino_styles.css
@@ -1,0 +1,79 @@
+#header #header-spacing .header-links .header-link.dropdown.active ul {
+  padding: 0;
+  display: block; }
+
+a > i.fa {
+  color: #0695d6;
+  font-family: FontAwesome;
+  font-weight: normal;
+}
+div.footer-section > p > a > i.fa:hover {
+  color: white !important;
+}
+section#home #hero {
+  height: 270px !important;
+}
+div#hero > div.hero-caption {
+  font-size: 14px;
+  height: 60%;
+  top: 30% !important;
+}
+div#hero > div.hero-caption > div.container > .row > div > h1 {
+  font-size: 50px;
+  margin-bottom: 10px;
+}
+div#hero > div.hero-caption > div.container > .row > div > p {
+  font-size: 16px;
+}
+div#hero > div.hero-caption > div.container > .row:nth-child(2) {
+  height: 50px;
+}
+div#hero > div.hero-caption > div.container > .row:nth-child(2) > div,
+div#hero > div.hero-caption > div.container > .row:nth-child(2) > div > form,
+div#hero > div.hero-caption > div.container > .row:nth-child(2) > div > form > div,
+div#hero > div.hero-caption > div.container > .row:nth-child(2) > div > form > div > div,
+div#hero > div.hero-caption > div.container > .row:nth-child(2) > div > form > div > div > input {
+  height: inherit;
+}
+#form-hero-search {
+  margin-bottom: 0;
+}
+ a#btn-config {
+  padding-top: 20px !important;
+  font-size: 20px;
+}
+ div#detalle-panel > div.dp-header > h3.title-xsm {
+  font-size: 18px;
+}
+ div#root > div.wrapper {
+  background-image: inherit;
+}
+section#home > div#series-destacadas {
+  padding: 0 150px;
+}
+section#home > div#series-destacadas > div.container {
+  -webkit-box-shadow: 0 -2px 4px 0 rgba(150, 150, 150, 0.5);
+  padding: 30px 80px;
+  width: fit-content;
+}
+ div.share > span > ul.social {
+  padding: 0;
+}
+div.form-horizontal > div.form-group {
+  display: block;
+}
+div.form-horizontal > div.form-group > label.col-sm-3.control-label {
+  width: 25%;
+}
+div.form-horizontal > div.form-group > label.col-sm-3.control-label:after{
+  content: normal;
+}
+div.form-horizontal > div.form-group > label.col-sm-6.control-label {
+  padding-right: 0;
+}
+div.form-horizontal > div.form-group > label.col-sm-6.control-label:after {
+  content: normal;
+}
+div.col-xs-6.inline > div.form-horizontal > div.form-group {
+  margin-bottom: 0;
+}

--- a/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
+++ b/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
@@ -12,6 +12,7 @@
       {% resource 'seriestiempoarexplorer/assets/css/normalize.css' %}
       {% resource 'seriestiempoarexplorer/assets/css/react-datepicker.css' %}
       {% resource 'seriestiempoarexplorer/assets/css/main.css' %}
+      {% resource 'seriestiempoarexplorer/assets/css/andino_styles.css' %}
       {% resource 'seriestiempoarexplorer/assets/css/explorer_plugin.css' %}
 
 {% endblock %}

--- a/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
+++ b/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
@@ -29,7 +29,7 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
     <script type="text/javascript"
-            src="https://datosgobar.github.io/series-tiempo-ar-explorer/static/js/main.47896891.js"></script>
+            src="https://datosgobar.github.io/series-tiempo-ar-explorer/static/js/main.2b2a6eee.js"></script>
     <script>window.onload = function () {
         var myTrim = function(TS_ID) {
             return TS_ID.trim();


### PR DESCRIPTION
Realizo cambios en el archivo de estilos para una mejor visualización de la página del explorador de series de tiempo en Andino.

#### Cambios en `/series/api`:
* Tamaño de la sección del título y su texto
* Encapsulamiento de las tarjetas para las series de tiempo
* Fix de los íconos de redes sociales

#### Cambios en la visualización de una serie de tiempo
* Tamaño del botón `AGREGAR SERIES`
* Ubicación de los botones del gráfico
* Alineamiento de los parámetros del gráfico

Closes datosgobar/portal-andino#165