### PR TITLE
16 - Implemento parametro heroImageUrl del TSExplorer

### DIFF
--- a/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
+++ b/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
@@ -55,19 +55,21 @@
             catalogId: "{{ h.get_theme_config('portal-metadata.id', '') }}",
             useBrowserRouter: true,
             laps: {
-               Diaria: 90,
-               Mensual: 24,
-               Trimestral: 20,
-               Semestral: 10,
-               Anual: 10
+               Diaria: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.diaria') or 90 }}",
+               Mensual: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.mensual') or 24 }}",
+               Trimestral: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.mensual') or 24 }}",
+               Semestral: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.semestral') or 10 }}",
+               Anual: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.anual') or 10 }}"
             },
-            locale: 'AR',
-            formatChartUnits: true,
+            locale: "{{ h.get_theme_config('series_tiempo_ar_explorer.locale') or 'AR' }}",
+            formatChartUnits: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.diaria') or true }}",
             browserRouterConf: {
                 basename: "/series/api"
             },
-            heroImageUrl: "{{ bgUrl }}"
+            maxDecimals: "{{ h.get_theme_config('series_tiempo_ar_explorer.max-decimals') or 2 }}",
+            heroImageUrl: "{{ h.get_theme_config('series_tiempo_ar_explorer.hero-image-url') or bgUrl }}"
         });
+
     }</script>
 {% endblock %}
 

--- a/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
+++ b/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
@@ -1,5 +1,7 @@
 {% extends "gobar_page.html" %}
 
+{% set bgUrl = h.get_theme_config('title.background-image') or (h.get_from_config_file('ckan.site_url') + "/img/home_bg.png") %}
+
 {% block styles %}
       {{ super() }}
 
@@ -17,16 +19,13 @@
 
       {% set config_background_opacity = h.get_from_config_file('andino.background_opacity') %}
       {% set bgOpacity = config_background_opacity if config_background_opacity else '0.5' %}
-      {% set config_background_image = h.get_theme_config('title.background-image') %}
-      {% set bgUrl = config_background_image if config_background_image else (h.get_from_config_file('ckan.site_url') + "/img/home_bg.png") %}
 
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@2.5.0/dist/css/main.css" type="text/css">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@2.5.1/dist/css/main.css" type="text/css">
 
       <style type="text/css">
-	div#hero > div.container{background-color: rgba(0, 0, 0, {{ bgOpacity }} ); height: 100%;}
 
-	section#home #hero {background-image: url('{{ bgUrl }}');}
-    section#detalle #hero {background-image: url('{{ bgUrl }}');}
+        div#hero > div.hero-caption{background-color: rgba(0, 0, 0, {{ bgOpacity }} );}
+
       </style>
 
 {% endblock %}
@@ -37,7 +36,6 @@
     {{ super() }}
 
 
-
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3.2/jquery.easing.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
@@ -46,7 +44,7 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
     <script type="text/javascript"
-            src="https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@2.5.0/dist/js/main.js"></script>
+            src="https://cdn.jsdelivr.net/gh/datosgobar/series-tiempo-ar-explorer@2.5.1/dist/js/main.js"></script>
     <script>window.onload = function () {
         var myTrim = function(TS_ID) {
             return TS_ID.trim();
@@ -67,11 +65,11 @@
             formatChartUnits: true,
             browserRouterConf: {
                 basename: "/series/api"
-            }
+            },
+            heroImageUrl: "{{ bgUrl }}"
         });
     }</script>
 {% endblock %}
-
 
 
 {%- block content %}
@@ -82,4 +80,6 @@
     </div>
 
 </div>
-{% endblock -%}
+{% endblock %}
+
+

--- a/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
+++ b/ckanext/seriestiempoarexplorer/templates/seriestiempoarexplorer/series_explorer.html
@@ -57,17 +57,16 @@
             laps: {
                Diaria: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.diaria') or 90 }}",
                Mensual: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.mensual') or 24 }}",
-               Trimestral: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.mensual') or 24 }}",
+               Trimestral: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.trimestral') or 20 }}",
                Semestral: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.semestral') or 10 }}",
                Anual: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.anual') or 10 }}"
             },
             locale: "{{ h.get_theme_config('series_tiempo_ar_explorer.locale') or 'AR' }}",
-            formatChartUnits: "{{ h.get_theme_config('series_tiempo_ar_explorer.laps.diaria') or true }}",
             browserRouterConf: {
                 basename: "/series/api"
             },
             maxDecimals: "{{ h.get_theme_config('series_tiempo_ar_explorer.max-decimals') or 2 }}",
-            heroImageUrl: "{{ h.get_theme_config('series_tiempo_ar_explorer.hero-image-url') or bgUrl }}"
+            heroImageUrl: "{{ bgUrl }}"
         });
 
     }</script>


### PR DESCRIPTION
Comienzo a usar el nuevo parámetro del `TSExplorer`, `heroImageUrl`, para indicarle qué imagen usar de fondo para el banner del encabezado. Para ello:

- Actualizo la versión usada del Explorer a la 2.5.1
- Saco selectores de CSS para el `container`, ya que ahora es el div `hero-caption` quien se encarga de aplicar la transparencia a la imagen de fondo, y dicha imagen se pasa al `TSExplorer` en el tag de script.
- Le paso la variable `bgUrl`, que tiene la URL de la imagen a usar en el Explorer, al componente `TSExplorer` renderizado.

Closes #16 